### PR TITLE
Change rebuild schedule from every 3 hours to 6 hours

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,7 @@
 name: Build & Deploy
 on:
   schedule:
-    - cron: '0 */3 * * *'
+    - cron: '0 */6 * * *'
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
The dashboard rebuilds unnecessarily often right now. This cuts it down by half.